### PR TITLE
Add variant-configurable problem registry and variant telemetry

### DIFF
--- a/aiopslab/onboarding_evaluator.py
+++ b/aiopslab/onboarding_evaluator.py
@@ -41,7 +41,8 @@ class Evaluator:
         self.session = Session()
         print(f"Session ID: {self.session.session_id}")
         prob = self.probs.get_problem_instance(problem_id)
-        self.session.set_problem(prob, pid=problem_id)
+        canonical_pid = self.probs.get_canonical_id(problem_id)
+        self.session.set_problem(prob, pid=problem_id, canonical_pid=canonical_pid)
         self.session.set_agent(self.agent_name)
 
         print("Setting up OpenEBS...")

--- a/aiopslab/orchestrator/orchestrator.py
+++ b/aiopslab/orchestrator/orchestrator.py
@@ -19,11 +19,11 @@ import os
 
 
 class Orchestrator:
-    def __init__(self, results_dir=None):
+    def __init__(self, results_dir=None, problem_variant_mode: str | None = None):
         self.agent = None
         self.session = None
         self.parser = ResponseParser()
-        self.probs = ProblemRegistry()
+        self.probs = ProblemRegistry(variant_mode=problem_variant_mode)
         self.sprint = SessionPrint()
         self.execution_start_time = None
         self.execution_end_time = None
@@ -47,7 +47,8 @@ class Orchestrator:
         print(f"Session ID: {self.session.session_id}")
         prob = self.probs.get_problem_instance(problem_id)
         deployment = self.probs.get_problem_deployment(problem_id)
-        self.session.set_problem(prob, pid=problem_id)
+        canonical_pid = self.probs.get_canonical_id(problem_id)
+        self.session.set_problem(prob, pid=problem_id, canonical_pid=canonical_pid)
         self.session.set_agent(self.agent_name)
 
         if deployment != "docker":

--- a/clients/client.py
+++ b/clients/client.py
@@ -32,9 +32,17 @@ def parse_args():
                         help="Top-p for nucleus sampling (vLLM only)")
     parser.add_argument("--max-tokens", type=int, default=1024,
                         help="Maximum tokens to generate (vLLM only)")
+    parser.add_argument(
+        "--problem-variant-mode",
+        choices=["static", "variant"],
+        default=None,
+        help="Override problem registry variant mode (static or variant)",
+    )
     return parser.parse_args()
 
-async def run_agent(agent_name, problem_id, max_steps, model, temperature, top_p, max_tokens, repetition_penalty, use_wandb=False):
+async def run_agent(agent_name, problem_id, max_steps, model, temperature, top_p,
+                    max_tokens, repetition_penalty, use_wandb=False,
+                    problem_variant_mode=None):
     """Run an agent on a problem."""
     if use_wandb:
         # Initialize wandb running
@@ -60,7 +68,7 @@ async def run_agent(agent_name, problem_id, max_steps, model, temperature, top_p
         agent = agent_cls()
 
 
-    orchestrator = Orchestrator()
+    orchestrator = Orchestrator(problem_variant_mode=problem_variant_mode)
     orchestrator.register_agent(agent, name=f"{agent_name}-agent")
 
     try:
@@ -97,5 +105,6 @@ if __name__ == "__main__":
         top_p=args.top_p,
         max_tokens=args.max_tokens,
         repetition_penalty=args.repetition_penalty,
-        use_wandb=use_wandb
+        use_wandb=use_wandb,
+        problem_variant_mode=args.problem_variant_mode,
     ))


### PR DESCRIPTION
## Summary
- add canonical problem ids and variant-aware lookups in the problem registry with env/CLI controls
- persist canonical ids and variant metadata through the orchestrator, retry orchestrator, and session serialization for downstream analytics
- expose a CLI flag to toggle variant usage and propagate canonical ids where sessions are created

## Testing
- pytest tests/registry/test_get_actions.py *(fails: requires kube config in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cddf3cf758833082948efc8f8a9d30