### PR TITLE
Add variant metadata logging and tests

### DIFF
--- a/aiopslab/onboarding_evaluator.py
+++ b/aiopslab/onboarding_evaluator.py
@@ -192,7 +192,36 @@ class Evaluator:
             )
             self.sprint.result(results)
         
-        self.session.set_results(results)
+        variant_summary = None
+        if hasattr(self.session.problem, "get_variant_summary"):
+            try:
+                variant_summary = self.session.problem.get_variant_summary()
+            except Exception:
+                variant_summary = None
+
+        success_flag = None
+        if isinstance(results, dict):
+            success_flag = results.get("success")
+
+        if success_flag is None:
+            if env_response == SubmissionStatus.VALID_SUBMISSION:
+                success_flag = True
+            elif env_response == SubmissionStatus.INVALID_SUBMISSION:
+                success_flag = False
+
+        if success_flag is True:
+            agent_outcome = "success"
+        elif success_flag is False:
+            agent_outcome = "failure"
+        else:
+            agent_outcome = "unknown"
+
+        self.session.set_results(
+            results,
+            variant_summary=variant_summary,
+            agent_outcome=agent_outcome,
+            retry_count=getattr(self.session, "retry_count", 0),
+        )
         self.session.to_json()
         self.session.problem.recover_fault()
         

--- a/aiopslab/orchestrator/actions/base.py
+++ b/aiopslab/orchestrator/actions/base.py
@@ -4,16 +4,20 @@
 """Base class for task actions."""
 
 import os
-import pandas as pd
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
 from aiopslab.utils.actions import action, read, write
 from aiopslab.service.kubectl import KubeCtl
 from aiopslab.service.dock import Docker
 from aiopslab.service.shell import Shell
 
-# from aiopslab.observer import initialize_pod_and_service_lists
-from aiopslab.observer.metric_api import PrometheusAPI
-from aiopslab.observer.trace_api import TraceAPI
+if TYPE_CHECKING:  # pragma: no cover - only used for type checking
+    # Import lazily to avoid loading Kubernetes configuration during module import in tests
+    from aiopslab.observer.metric_api import PrometheusAPI
+    from aiopslab.observer.trace_api import TraceAPI
 
 
 class TaskActions:
@@ -103,6 +107,8 @@ class TaskActions:
         prometheus_url = (
             "http://localhost:32000"  # Replace with your Prometheus server URL
         )
+        from aiopslab.observer.metric_api import PrometheusAPI
+
         prometheus_api = PrometheusAPI(prometheus_url, namespace)
         prometheus_api.initialize_pod_and_service_lists(namespace)
 
@@ -155,6 +161,8 @@ class TaskActions:
         """
         # jaeger_url = "http://localhost:16686"
         print(namespace)
+        from aiopslab.observer.trace_api import TraceAPI
+
         trace_api = TraceAPI(namespace=namespace)
 
         end_time = datetime.now()

--- a/aiopslab/orchestrator/orchestrator.py
+++ b/aiopslab/orchestrator/orchestrator.py
@@ -189,7 +189,36 @@ class Orchestrator:
             )
             self.sprint.result(results)
 
-        self.session.set_results(results)
+        variant_summary = None
+        if hasattr(self.session.problem, "get_variant_summary"):
+            try:
+                variant_summary = self.session.problem.get_variant_summary()
+            except Exception:
+                variant_summary = None
+
+        success_flag = None
+        if isinstance(results, dict):
+            success_flag = results.get("success")
+
+        if success_flag is None:
+            if env_response == SubmissionStatus.VALID_SUBMISSION:
+                success_flag = True
+            elif env_response == SubmissionStatus.INVALID_SUBMISSION:
+                success_flag = False
+
+        if success_flag is True:
+            agent_outcome = "success"
+        elif success_flag is False:
+            agent_outcome = "failure"
+        else:
+            agent_outcome = "unknown"
+
+        self.session.set_results(
+            results,
+            variant_summary=variant_summary,
+            agent_outcome=agent_outcome,
+            retry_count=getattr(self.session, "retry_count", 0),
+        )
         self.session.to_json()
         if self.use_wandb:
             self.session.to_wandb()

--- a/aiopslab/orchestrator/problems/container_kill/container_kill_variant.py
+++ b/aiopslab/orchestrator/problems/container_kill/container_kill_variant.py
@@ -7,7 +7,12 @@ from typing import Any, Dict
 import yaml
 from aiopslab.orchestrator.tasks import DetectionTask, LocalizationTask
 from aiopslab.orchestrator.tasks.variant_task import VariantTask
-from aiopslab.orchestrator.variant_generator import ServiceVariantGenerator, ConfigVariantGenerator, CompositeVariantGenerator
+from aiopslab.orchestrator.variant_generator import (
+    VariantGenerator,
+    ServiceVariantGenerator,
+    ConfigVariantGenerator,
+    CompositeVariantGenerator,
+)
 from aiopslab.orchestrator.evaluators.quantitative import *
 from aiopslab.service.kubectl import KubeCtl
 from aiopslab.service.apps.hotelres import HotelReservation
@@ -58,7 +63,6 @@ class ContainerKillVariantBase(VariantTask):
             # We'll use ConfigVariantGenerator with a special handling
             class ServiceContainerVariantGenerator(VariantGenerator):
                 def __init__(self, base_config, pairs):
-                    from aiopslab.orchestrator.variant_generator import VariantGenerator
                     super().__init__(base_config)
                     self.pairs = pairs
                     self.used_indices = set()

--- a/aiopslab/orchestrator/retry_orchestrator.py
+++ b/aiopslab/orchestrator/retry_orchestrator.py
@@ -69,7 +69,10 @@ class RetryOrchestrator:
         for attempt in range(self.max_retries + 1):
             print(f"\n{'='*60}")
             print(f"Attempt {attempt + 1}/{self.max_retries + 1}")
-            
+
+            if isinstance(self.orchestrator.session, Session):
+                self.orchestrator.session.retry_count = attempt
+
             # Apply variant if this is a retry and variants are enabled
             if attempt > 0 and self.enable_variants:
                 if isinstance(self.orchestrator.session.problem, VariantTask):

--- a/aiopslab/orchestrator/tasks/variant_task.py
+++ b/aiopslab/orchestrator/tasks/variant_task.py
@@ -18,7 +18,9 @@ class VariantTask(Task):
         Args:
             variant_generator: Optional variant generator for creating task variations
         """
-        super().__init__()
+        # Call Task.__init__ directly to avoid invoking other mixins in the MRO
+        # that expect additional initialization arguments.
+        Task.__init__(self)
         self.variant_generator = variant_generator
         self.current_variant = None
         self.variant_history = []

--- a/docs/variant_catalogue.md
+++ b/docs/variant_catalogue.md
@@ -1,0 +1,60 @@
+# Variant Catalogue
+
+This catalogue summarizes the variant-enabled scenarios available to the reinforcement learning curriculum. For each problem family we list the variant knobs that are exercised, the fault injection entry points, and the evaluation signals agents must optimize.
+
+## Hotel Reservation – Network Symptoms
+
+### Network Loss Detection & Localization
+- **Variant knobs:** Composite generator sweeps the faulty microservice label through the Hotel Reservation topology and varies packet loss severity via a numeric schedule.【F:aiopslab/orchestrator/problems/network_loss/network_loss_variant.py†L23-L55】
+- **Fault model:** Every variant delegates to the `SymptomFaultInjector.inject_network_loss` helper, targeting the active service for loss injection.【F:aiopslab/orchestrator/problems/network_loss/network_loss_variant.py†L89-L99】
+- **Evaluation:** Detection agents must answer "Yes" to achieve a `Detection Accuracy` reward, while localization agents are graded on `Localization Accuracy`, `success`, and subset flags derived from set comparisons against the injected service list.【F:aiopslab/orchestrator/problems/network_loss/network_loss_variant.py†L110-L168】
+
+### Network Delay Detection & Localization
+- **Variant knobs:** A composite generator rotates the impacted microservice and the injected latency (50–1000 ms) to stress agents across network tiers.【F:aiopslab/orchestrator/problems/network_delay/network_delay_variant.py†L23-L55】
+- **Fault model:** Variants call `SymptomFaultInjector.inject_network_delay`, logging the currently selected service and delay budget.【F:aiopslab/orchestrator/problems/network_delay/network_delay_variant.py†L89-L100】
+- **Evaluation:** As with network loss, detection expects a "Yes" submission and localization rewards exact or subset matches, emitting `Localization Accuracy`, `success`, and `is_subset` metrics.【F:aiopslab/orchestrator/problems/network_delay/network_delay_variant.py†L110-L168】
+
+## Hotel Reservation – Pod Disruptions
+
+### Pod Failure Detection & Localization
+- **Variant knobs:** The service variant generator ranges across front-end, application, cache, and MongoDB services when selecting the failed pod.【F:aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py†L23-L48】
+- **Fault model:** The `SymptomFaultInjector._inject` call issues a `pod_failure` chaos experiment scoped to the current service label.【F:aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py†L77-L89】
+- **Evaluation:** Detection problems again check for "Yes", while localization computes accuracy from exact or subset matches and updates `success`/`is_subset` flags.【F:aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py†L100-L158】
+
+### Pod Kill Detection & Localization
+- **Variant knobs:** A composite generator couples service selection with discrete duration choices (50 s–300 s) to cover short-lived versus long-lived disruptions.【F:aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py†L23-L58】
+- **Fault model:** `SymptomFaultInjector._inject` issues `pod_kill` with the active service list and the variant-specific duration.【F:aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py†L92-L104】
+- **Evaluation:** Detection and localization follow the same scoring templates as above, logging `Detection Accuracy` or `Localization Accuracy` and boolean success summaries.【F:aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py†L115-L173】
+
+### Container Kill Detection & Localization
+- **Variant knobs:** A bespoke generator iterates through service/container name pairs so agents see container-level failures as well as service-level outages.【F:aiopslab/orchestrator/problems/container_kill/container_kill_variant.py†L24-L76】
+- **Fault model:** Variants invoke `SymptomFaultInjector.inject_container_kill` with the synchronized service and container identifiers.【F:aiopslab/orchestrator/problems/container_kill/container_kill_variant.py†L112-L125】
+- **Evaluation:** Detection requires the canonical "Yes" answer, and localization tracks accuracy plus `success` and `is_subset` results for the reported component list.【F:aiopslab/orchestrator/problems/container_kill/container_kill_variant.py†L134-L192】
+
+## Hotel Reservation – Application Misconfiguration
+
+### Misconfig Application Detection & Localization
+- **Variant knobs:** Service variants span Hotel Reservation tiers while a configuration generator toggles environment, port, connection, memory, and timeout faults.【F:aiopslab/orchestrator/problems/misconfig_app/misconfig_app_variant.py†L24-L57】
+- **Fault model:** The variant feeds the selected microservice to `ApplicationFaultInjector._inject` under the `misconfig_app` fault type.【F:aiopslab/orchestrator/problems/misconfig_app/misconfig_app_variant.py†L90-L99】
+- **Evaluation:** Detection expects "Yes" to mark `Detection Accuracy` as correct; localization rewards matching the targeted service and reports `Localization Accuracy`, `success`, and subset information.【F:aiopslab/orchestrator/problems/misconfig_app/misconfig_app_variant.py†L117-L179】
+
+## TiDB Operator – Control Plane Misoperations
+
+### Operator Misoperation Detection & Localization
+- **Variant knobs:** Configuration variants sweep misoperation type, extreme replica counts, toleration effects, security context user IDs, update strategies, and storage classes to probe a wide envelope of operator mistakes.【F:aiopslab/orchestrator/problems/operator_misoperation/operator_misoperation_variant.py†L23-L63】
+- **Fault model:** Depending on the active `fault_type`, the variant triggers the corresponding `K8SOperatorFaultInjector._inject` routine with descriptive logging for curriculum analysis.【F:aiopslab/orchestrator/problems/operator_misoperation/operator_misoperation_variant.py†L101-L125】
+- **Evaluation:** Detection keeps the "Yes"/"No" contract, while localization compares predicted custom resources to the ground truth and surfaces accuracy plus `success` metadata.【F:aiopslab/orchestrator/problems/operator_misoperation/operator_misoperation_variant.py†L147-L221】
+
+## Social Network – Scaling and Routing Faults
+
+### Scale Pod Detection & Localization
+- **Variant knobs:** The service generator cycles through the Social Network frontend, backend, cache, and data services to test scaling competence across domains.【F:aiopslab/orchestrator/problems/scale_pod/scale_pod_variant.py†L23-L65】
+- **Fault model:** Variants call `VirtualizationFaultInjector._inject` with `scale_pods_to_zero`, effectively scaling the chosen service to zero replicas.【F:aiopslab/orchestrator/problems/scale_pod/scale_pod_variant.py†L95-L112】
+- **Evaluation:** Detection relies on the binary "Yes" submission, and localization reuses the accuracy plus success bookkeeping pattern established above.【F:aiopslab/orchestrator/problems/scale_pod/scale_pod_variant.py†L118-L180】
+
+### Kubernetes Target Port Misconfiguration Detection & Localization
+- **Variant knobs:** Service selection spans the Social Network mesh while the base configuration keeps a default wrong port that agents can override through variants.【F:aiopslab/orchestrator/problems/k8s_target_port_misconfig/target_port_variant.py†L23-L54】
+- **Fault model:** The `VirtualizationFaultInjector._inject` call introduces the misconfigured target port for the active service list.【F:aiopslab/orchestrator/problems/k8s_target_port_misconfig/target_port_variant.py†L93-L114】
+- **Evaluation:** Detection again expects "Yes", and localization measures accuracy for the faulty service along with boolean success diagnostics.【F:aiopslab/orchestrator/problems/k8s_target_port_misconfig/target_port_variant.py†L120-L183】
+
+These summaries provide a quick reference to the diversity of variant knobs and evaluation lenses available, enabling practitioners to design curricula that systematically cover network, infrastructure, and control-plane fault modes.

--- a/tests/orchestrator/test_session_logging.py
+++ b/tests/orchestrator/test_session_logging.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import atexit
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "aiopslab" / "config.yml"
+if not CONFIG_PATH.exists():
+    example = CONFIG_PATH.with_suffix('.yml.example')
+    if example.exists():
+        CONFIG_PATH.write_text(example.read_text())
+    else:
+        CONFIG_PATH.write_text('data_dir: data\nprint_session: false\n')
+    atexit.register(lambda path=CONFIG_PATH: path.unlink(missing_ok=True))
+
+from aiopslab.session import Session
+
+
+class DummyProblem:
+    def __init__(self, summary="Variant: foo=bar"):
+        self._summary = summary
+
+    def get_variant_summary(self):
+        return self._summary
+
+
+def test_session_records_variant_metadata():
+    session = Session()
+    session.set_problem(DummyProblem(), pid="dummy")
+    session.set_agent("agent")
+    session.retry_count = 2
+
+    session.set_results({"success": True})
+
+    assert session.variant_summary == "Variant: foo=bar"
+    assert session.agent_outcome == "success"
+    assert session.retry_count == 2
+
+    summary = session.to_dict()
+    assert summary["variant_summary"] == "Variant: foo=bar"
+    assert summary["agent_outcome"] == "success"
+    assert summary["retry_count"] == 2
+
+
+def test_session_set_results_allows_overrides():
+    session = Session()
+    session.set_problem(DummyProblem("Base configuration"), pid="dummy")
+
+    session.set_results({}, variant_summary="custom summary", agent_outcome="failure", retry_count=5)
+
+    assert session.variant_summary == "custom summary"
+    assert session.agent_outcome == "failure"
+    assert session.retry_count == 5

--- a/tests/orchestrator/test_variant_generators.py
+++ b/tests/orchestrator/test_variant_generators.py
@@ -1,0 +1,182 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import atexit
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "aiopslab" / "config.yml"
+if not CONFIG_PATH.exists():
+    example = CONFIG_PATH.with_suffix('.yml.example')
+    if example.exists():
+        CONFIG_PATH.write_text(example.read_text())
+    else:
+        CONFIG_PATH.write_text('data_dir: data\nprint_session: false\n')
+    atexit.register(lambda path=CONFIG_PATH: path.unlink(missing_ok=True))
+
+import random
+from typing import Dict
+
+import pytest
+
+from aiopslab.orchestrator.tasks.variant_task import VariantTask
+from aiopslab.orchestrator.variant_generator import (
+    ConfigVariantGenerator,
+    CompositeVariantGenerator,
+    NumericVariantGenerator,
+    PortMisconfigVariantGenerator,
+    ReplicaVariantGenerator,
+    ServiceVariantGenerator,
+)
+
+
+class StubKubeCtl:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            return None
+
+        return method
+
+
+@pytest.fixture(autouse=True)
+def stub_kubectl(monkeypatch):
+    monkeypatch.setattr("aiopslab.orchestrator.tasks.base.KubeCtl", StubKubeCtl)
+
+
+class DummyVariantTask(VariantTask):
+    def __init__(self, generator):
+        super().__init__(generator)
+        for key, value in generator.base_config.items():
+            setattr(self, key, value)
+
+    def get_task_description(self):
+        return ""
+
+    def get_instructions(self):
+        return ""
+
+    def get_available_actions(self):
+        return []
+
+    def perform_action(self, action_name, *args, **kwargs):
+        raise NotImplementedError
+
+
+def _assert_reset_to_base(generator, variant_overrides: Dict[str, object]):
+    task = DummyVariantTask(generator)
+    task.apply_variant(variant_overrides)
+
+    for key, value in variant_overrides.items():
+        assert getattr(task, key) == value
+
+    task.reset_to_base()
+
+    for key, value in generator.base_config.items():
+        assert getattr(task, key) == value
+
+
+def test_port_misconfig_generator_unique_and_reset():
+    base_config = {"wrong_port": 9000}
+    generator = PortMisconfigVariantGenerator(base_config.copy())
+    random.seed(0)
+    variants = generator.generate_variants(5)
+
+    ports = {variant["wrong_port"] for variant in variants}
+    assert len(ports) == len(variants)
+    assert generator.base_config["wrong_port"] == 9000
+
+    reset_generator = PortMisconfigVariantGenerator(base_config.copy())
+    first_variant = reset_generator.generate_variants(1)[0]
+    _assert_reset_to_base(reset_generator, first_variant)
+
+
+def test_service_variant_generator_unique_and_reset():
+    base_config = {"faulty_service": "user"}
+    services = ["user", "geo", "profile", "search"]
+    generator = ServiceVariantGenerator(base_config.copy(), services)
+    random.seed(1)
+    variants = generator.generate_variants(3)
+
+    selected = {variant["faulty_service"] for variant in variants}
+    assert len(selected) == len(variants)
+    assert generator.base_config["faulty_service"] == "user"
+
+    reset_generator = ServiceVariantGenerator(base_config.copy(), services)
+    first_variant = reset_generator.generate_variants(1)[0]
+    _assert_reset_to_base(reset_generator, first_variant)
+
+
+def test_replica_variant_generator_unique_and_reset():
+    base_config = {"replica_count": 3}
+    generator = ReplicaVariantGenerator(base_config.copy())
+    variants = generator.generate_variants(4)
+
+    counts = [variant["replica_count"] for variant in variants]
+    assert len(set(counts)) == len(counts)
+
+    reset_generator = ReplicaVariantGenerator(base_config.copy())
+    variant = reset_generator.generate_variants(1)[0]
+    _assert_reset_to_base(reset_generator, variant)
+
+
+def test_config_variant_generator_unique_and_reset():
+    base_config = {"faulty_service": "geo", "config_type": "env"}
+    config_variants = {
+        "faulty_service": ["geo", "profile", "rate"],
+        "config_type": ["env", "port", "memory"],
+    }
+    generator = ConfigVariantGenerator(base_config.copy(), config_variants)
+    variants = generator.generate_variants(5)
+
+    combos = {tuple(sorted(variant.items())) for variant in variants}
+    assert len(combos) == len(variants)
+
+    reset_generator = ConfigVariantGenerator(base_config.copy(), config_variants)
+    variant = reset_generator.generate_variants(1)[0]
+    _assert_reset_to_base(reset_generator, variant)
+
+
+def test_numeric_variant_generator_unique_and_reset():
+    base_config = {"loss_rate": 0.1}
+    values = [0.05, 0.1, 0.2, 0.3]
+    generator = NumericVariantGenerator(base_config.copy(), "loss_rate", values=values)
+    variants = generator.generate_variants(4)
+
+    magnitudes = [variant["loss_rate"] for variant in variants]
+    assert len(set(magnitudes)) == len(magnitudes)
+
+    reset_generator = NumericVariantGenerator(base_config.copy(), "loss_rate", values=values)
+    variant = reset_generator.generate_variants(1)[0]
+    _assert_reset_to_base(reset_generator, variant)
+
+
+def test_composite_variant_generator_unique_and_reset(monkeypatch):
+    base_config = {"faulty_service": "user", "loss_rate": 0.1}
+    services = ["user", "geo"]
+    values = [0.1, 0.2]
+
+    service_generator = ServiceVariantGenerator(base_config.copy(), services)
+    numeric_generator = NumericVariantGenerator(base_config.copy(), "loss_rate", values=values)
+
+    composite = CompositeVariantGenerator([service_generator, numeric_generator])
+
+    monkeypatch.setattr(
+        "aiopslab.orchestrator.variant_generator.random.choice",
+        lambda options: options[0],
+    )
+
+    variants = composite.generate_variants(4)
+    combos = {tuple(sorted(variant.items())) for variant in variants}
+    assert len(combos) == len(variants)
+
+    reset_generator = CompositeVariantGenerator(
+        [
+            ServiceVariantGenerator(base_config.copy(), services),
+            NumericVariantGenerator(base_config.copy(), "loss_rate", values=values),
+        ]
+    )
+    override = {"faulty_service": "geo", "loss_rate": 0.3}
+    _assert_reset_to_base(reset_generator, override)

--- a/tests/orchestrator/test_variant_scenarios.py
+++ b/tests/orchestrator/test_variant_scenarios.py
@@ -1,0 +1,192 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import atexit
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "aiopslab" / "config.yml"
+if not CONFIG_PATH.exists():
+    example = CONFIG_PATH.with_suffix('.yml.example')
+    if example.exists():
+        CONFIG_PATH.write_text(example.read_text())
+    else:
+        CONFIG_PATH.write_text('data_dir: data\nprint_session: false\n')
+    atexit.register(lambda path=CONFIG_PATH: path.unlink(missing_ok=True))
+
+from aiopslab.orchestrator.tasks import AnalysisTask, MitigationTask
+
+
+class StubKubeCtl:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            return None
+
+        return method
+
+
+class StubApp:
+    def __init__(self, *args, **kwargs):
+        self.namespace = "test-ns"
+        self.helm_configs = {}
+
+    def get_app_summary(self):
+        return "stub app"
+
+    def delete(self):
+        return None
+
+    def deploy(self):
+        return None
+
+    def cleanup(self):
+        return None
+
+
+class StubWrk:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    def start_workload(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+@pytest.fixture(autouse=True)
+def stub_task_kubectl(monkeypatch):
+    monkeypatch.setattr("aiopslab.orchestrator.tasks.base.KubeCtl", StubKubeCtl)
+
+
+def test_network_loss_detection_injects_selected_service(monkeypatch):
+    from aiopslab.orchestrator.problems.network_loss import network_loss_variant as network_loss
+
+    class RecordingLossInjector:
+        def __init__(self, namespace):
+            self.namespace = namespace
+            self.calls = []
+
+        def inject_network_loss(self, services):
+            self.calls.append(list(services))
+
+        def recover_network_loss(self):
+            self.calls.append(("recover", None))
+
+    monkeypatch.setattr(network_loss, "HotelReservation", StubApp)
+    monkeypatch.setattr(network_loss, "KubeCtl", StubKubeCtl)
+    monkeypatch.setattr(network_loss, "Wrk", StubWrk)
+    monkeypatch.setattr(network_loss, "SymptomFaultInjector", RecordingLossInjector)
+
+    variant = network_loss.NetworkLossVariantDetection(enable_variants=True)
+    next_variant = variant.get_next_variant()
+    if next_variant:
+        variant.apply_variant(next_variant)
+
+    variant.inject_fault()
+    assert variant.injector.calls[-1] == [variant.faulty_service]
+
+
+def test_container_kill_localization_targets_service_and_container(monkeypatch):
+    from aiopslab.orchestrator.problems.container_kill import container_kill_variant as container_kill
+
+    class RecordingContainerInjector:
+        def __init__(self, namespace):
+            self.namespace = namespace
+            self.calls = []
+
+        def inject_container_kill(self, service, container):
+            self.calls.append((service, container))
+
+        def recover_container_kill(self):
+            self.calls.append(("recover", None))
+
+    monkeypatch.setattr(container_kill, "HotelReservation", StubApp)
+    monkeypatch.setattr(container_kill, "KubeCtl", StubKubeCtl)
+    monkeypatch.setattr(container_kill, "Wrk", StubWrk)
+    monkeypatch.setattr(container_kill, "SymptomFaultInjector", RecordingContainerInjector)
+
+    variant = container_kill.ContainerKillVariantLocalization(enable_variants=True)
+    next_variant = variant.get_next_variant()
+    if next_variant:
+        variant.apply_variant(next_variant)
+    else:
+        variant.apply_variant({"faulty_service": "profile", "faulty_container": "hotel-reserv-profile"})
+
+    variant.inject_fault()
+    assert variant.symptom_injector.calls[-1] == (variant.faulty_service, variant.faulty_container)
+
+
+def test_operator_misoperation_analysis_injects_fault_type(monkeypatch):
+    from aiopslab.orchestrator.problems.operator_misoperation import operator_misoperation_variant as operator_variant
+
+    class StubTiDBCluster(StubApp):
+        pass
+
+    class RecordingOperatorInjector:
+        def __init__(self, namespace):
+            self.namespace = namespace
+            self.calls = []
+
+        def _inject(self, fault_type):
+            self.calls.append(fault_type)
+
+        def _recover(self, fault_type):
+            self.calls.append(("recover", fault_type))
+
+    monkeypatch.setattr(operator_variant, "TiDBCluster", StubTiDBCluster)
+    monkeypatch.setattr(operator_variant, "K8SOperatorFaultInjector", RecordingOperatorInjector)
+
+    class AnalysisVariant(operator_variant.K8SOperatorMisoperationVariantBase, AnalysisTask):
+        def __init__(self, fault_type="overload_replicas"):
+            operator_variant.K8SOperatorMisoperationVariantBase.__init__(
+                self, fault_type=fault_type, enable_variants=True
+            )
+            AnalysisTask.__init__(self, self.app)
+
+    variant = AnalysisVariant()
+    variant.apply_variant({"fault_type": "security_context_fault"})
+
+    variant.inject_fault()
+    assert variant.injector.calls[-1] == "security_context_fault"
+
+
+def test_pod_kill_mitigation_passes_duration_and_service(monkeypatch):
+    from aiopslab.orchestrator.problems.pod_kill import pod_kill_variant as pod_kill
+
+    class RecordingPodKillInjector:
+        def __init__(self, namespace):
+            self.namespace = namespace
+            self.calls = []
+
+        def _inject(self, fault_type, microservices, duration):
+            self.calls.append({
+                "fault_type": fault_type,
+                "microservices": list(microservices),
+                "duration": duration,
+            })
+
+        def _recover(self, fault_type):
+            self.calls.append(("recover", fault_type))
+
+    monkeypatch.setattr(pod_kill, "HotelReservation", StubApp)
+    monkeypatch.setattr(pod_kill, "KubeCtl", StubKubeCtl)
+    monkeypatch.setattr(pod_kill, "Wrk", StubWrk)
+    monkeypatch.setattr(pod_kill, "SymptomFaultInjector", RecordingPodKillInjector)
+
+    class PodKillMitigation(pod_kill.PodKillVariantBase, MitigationTask):
+        def __init__(self, faulty_service="user", duration="100s"):
+            pod_kill.PodKillVariantBase.__init__(
+                self, faulty_service=faulty_service, duration=duration, enable_variants=True
+            )
+            MitigationTask.__init__(self, self.app)
+
+    variant = PodKillMitigation()
+    variant.apply_variant({"faulty_service": "reservation", "duration": "300s"})
+
+    variant.inject_fault()
+    call = variant.injector.calls[-1]
+    assert call["fault_type"] == "pod_kill"
+    assert call["microservices"] == [variant.faulty_service]
+    assert call["duration"] == variant.duration


### PR DESCRIPTION
## Summary
- ensure variant generators deduplicate combinations and share merged base configs for composite tasks
- record variant metadata, agent outcomes, and retry counts through orchestrators and sessions for logging
- add documentation and tests covering variant generators, scenario smoke flows, and session logging

## Testing
- pytest tests/orchestrator/test_variant_generators.py tests/orchestrator/test_variant_scenarios.py tests/orchestrator/test_session_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68cddf440bc08330b13dfa00b6dd056f