### PR TITLE
Add analysis and mitigation tasks for pod failure

### DIFF
--- a/aiopslab/orchestrator/problems/pod_failure/__init__.py
+++ b/aiopslab/orchestrator/problems/pod_failure/__init__.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 
 from .pod_failure import (
+    PodFailureAnalysis,
     PodFailureDetection,
     PodFailureLocalization,
+    PodFailureMitigation,
 )

--- a/aiopslab/orchestrator/problems/registry.py
+++ b/aiopslab/orchestrator/problems/registry.py
@@ -30,8 +30,10 @@ from aiopslab.orchestrator.problems.container_kill.container_kill_variant import
 )
 from aiopslab.orchestrator.problems.pod_failure import *
 from aiopslab.orchestrator.problems.pod_failure.pod_failure_variant import (
+    PodFailureVariantAnalysis,
     PodFailureVariantDetection,
     PodFailureVariantLocalization,
+    PodFailureVariantMitigation,
 )
 from aiopslab.orchestrator.problems.pod_kill import *
 from aiopslab.orchestrator.problems.pod_kill.pod_kill_variant import (
@@ -196,6 +198,8 @@ class ProblemRegistry:
             # Pod failure
             "pod_failure_hotel_res-detection-1": PodFailureDetection,
             "pod_failure_hotel_res-localization-1": PodFailureLocalization,
+            "pod_failure_hotel_res-analysis-1": PodFailureAnalysis,
+            "pod_failure_hotel_res-mitigation-1": PodFailureMitigation,
             # Pod kill
             "pod_kill_hotel_res-detection-1": PodKillDetection,
             "pod_kill_hotel_res-localization-1": PodKillLocalization,
@@ -438,6 +442,18 @@ class ProblemRegistry:
                 enable_variants=True
             ),
             "pod_failure_hotel_res-localization-1": lambda: PodFailureVariantLocalization(
+                faulty_service="user", enable_variants=True
+            ),
+            "pod_failure_hotel_res-analysis": lambda: PodFailureVariantAnalysis(
+                enable_variants=True
+            ),
+            "pod_failure_hotel_res-analysis-1": lambda: PodFailureVariantAnalysis(
+                faulty_service="user", enable_variants=True
+            ),
+            "pod_failure_hotel_res-mitigation": lambda: PodFailureVariantMitigation(
+                enable_variants=True
+            ),
+            "pod_failure_hotel_res-mitigation-1": lambda: PodFailureVariantMitigation(
                 faulty_service="user", enable_variants=True
             ),
             # Pod kill (Hotel Reservation)

--- a/docs/variant_catalogue.md
+++ b/docs/variant_catalogue.md
@@ -74,17 +74,18 @@ curriculum authors can quickly inspect the grading logic.
   using the `pod_failure` scenario.
 - **Variant coverage**: [`PodFailureVariantBase`](../aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py)
   rotates the affected Hotel Reservation service.
-- **Analysis expectations**: variant RCA expects
+- **Analysis expectations**: both static and variant RCAs expect
   `system_level="Virtualization"` / `fault_type="Operation Error"`.
-- **Mitigation checks**: variant mitigation relies on the mixin's `pods_ready`
-  expectation; there is no bespoke static mitigation task yet.
+- **Mitigation checks**: the static task polls until every pod in the namespace
+  reports ready via `kubectl`, while the variant mitigation relies on the
+  mixin's `pods_ready` expectation for the affected service.
 
 | Role | Static task | Variant task | Evaluation focus |
 | --- | --- | --- | --- |
 | Detection | [`PodFailureDetection`](../aiopslab/orchestrator/problems/pod_failure/pod_failure.py) | [`PodFailureVariantDetection`](../aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py) | Case-insensitive `"Yes"`. |
 | Localization | [`PodFailureLocalization`](../aiopslab/orchestrator/problems/pod_failure/pod_failure.py) | [`PodFailureVariantLocalization`](../aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py) | Requires the failed service name. |
-| Analysis | – | [`PodFailureVariantAnalysis`](../aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py) | Uses mixin metadata (`Virtualization` / `Operation Error`). |
-| Mitigation | – | [`PodFailureVariantMitigation`](../aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py) | Uses `pods_ready` for the affected service. |
+| Analysis | [`PodFailureAnalysis`](../aiopslab/orchestrator/problems/pod_failure/pod_failure.py) | [`PodFailureVariantAnalysis`](../aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py) | Validates `Virtualization` / `Operation Error`. |
+| Mitigation | [`PodFailureMitigation`](../aiopslab/orchestrator/problems/pod_failure/pod_failure.py) | [`PodFailureVariantMitigation`](../aiopslab/orchestrator/problems/pod_failure/pod_failure_variant.py) | Static task polls for all pods in the namespace; variant uses `pods_ready`. |
 
 ## Hotel Reservation pod kill
 


### PR DESCRIPTION
## Summary
- add static pod failure analysis and mitigation evaluators that mirror the variant expectations
- register the new tasks in the problem registry and document their coverage in the variant catalogue

## Testing
- `pytest tests/orchestrator/test_variant_scenarios.py -k "registry_returns_variant_rca_mitigation_tasks" -q`


------
https://chatgpt.com/codex/tasks/task_e_68cdfbc89d188330bfec8fca565b0345