### PR TITLE
Add static analysis and mitigation coverage for pod kill

### DIFF
--- a/aiopslab/orchestrator/problems/pod_kill/__init__.py
+++ b/aiopslab/orchestrator/problems/pod_kill/__init__.py
@@ -1,4 +1,6 @@
 from .pod_kill import (
+    PodKillAnalysis,
     PodKillDetection,
     PodKillLocalization,
+    PodKillMitigation,
 )

--- a/aiopslab/orchestrator/problems/registry.py
+++ b/aiopslab/orchestrator/problems/registry.py
@@ -199,6 +199,8 @@ class ProblemRegistry:
             # Pod kill
             "pod_kill_hotel_res-detection-1": PodKillDetection,
             "pod_kill_hotel_res-localization-1": PodKillLocalization,
+            "pod_kill_hotel_res-analysis-1": PodKillAnalysis,
+            "pod_kill_hotel_res-mitigation-1": PodKillMitigation,
             # Network loss
             "network_loss_hotel_res-detection-1": NetworkLossDetection,
             "network_loss_hotel_res-localization-1": NetworkLossLocalization,

--- a/docs/variant_catalogue.md
+++ b/docs/variant_catalogue.md
@@ -92,17 +92,19 @@ curriculum authors can quickly inspect the grading logic.
   with the `pod_kill` experiment (duration is variant-controlled).
 - **Variant coverage**: [`PodKillVariantBase`](../aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py)
   varies both the target service and the kill duration.
-- **Analysis expectations**: mixin metadata records
-  `system_level="Virtualization"` / `fault_type="Operation Error"`.
-- **Mitigation checks**: variant mitigation uses the `pods_ready`
-  expectation for the chosen service.
+- **Analysis expectations**: the static task enforces the
+  `system_level="Virtualization"` / `fault_type="Operation Error"`
+  pairing; the variant metadata records the same requirement.
+- **Mitigation checks**: static mitigation polls until the affected
+  service's pods report Ready; the variant mitigation continues to rely
+  on the mixin's `pods_ready` expectation.
 
 | Role | Static task | Variant task | Evaluation focus |
 | --- | --- | --- | --- |
 | Detection | [`PodKillDetection`](../aiopslab/orchestrator/problems/pod_kill/pod_kill.py) | [`PodKillVariantDetection`](../aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py) | Case-insensitive `"Yes"`. |
 | Localization | [`PodKillLocalization`](../aiopslab/orchestrator/problems/pod_kill/pod_kill.py) | [`PodKillVariantLocalization`](../aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py) | Requires the killed service name. |
-| Analysis | – | [`PodKillVariantAnalysis`](../aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py) | Validates `Virtualization` / `Operation Error`. |
-| Mitigation | – | [`PodKillVariantMitigation`](../aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py) | Ensures pods become ready again. |
+| Analysis | [`PodKillAnalysis`](../aiopslab/orchestrator/problems/pod_kill/pod_kill.py) | [`PodKillVariantAnalysis`](../aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py) | Validates `Virtualization` / `Operation Error`. |
+| Mitigation | [`PodKillMitigation`](../aiopslab/orchestrator/problems/pod_kill/pod_kill.py) | [`PodKillVariantMitigation`](../aiopslab/orchestrator/problems/pod_kill/pod_kill_variant.py) | Ensures pods become ready again. |
 
 ## Hotel Reservation network loss
 


### PR DESCRIPTION
## Summary
- add static pod kill analysis and mitigation tasks that check the Virtualization/Operation Error pairing and pod readiness
- expose the new tasks through the pod kill package and ProblemRegistry so canonical IDs resolve to the new implementations
- refresh the variant catalogue documentation to describe the expanded static coverage

## Testing
- pytest tests/orchestrator/test_variant_scenarios.py

------
https://chatgpt.com/codex/tasks/task_e_68cdfbcedcf48330bbea690418dde6a4