### PR TITLE
Add network delay analysis and mitigation stages

### DIFF
--- a/aiopslab/orchestrator/problems/network_delay/__init__.py
+++ b/aiopslab/orchestrator/problems/network_delay/__init__.py
@@ -1,4 +1,6 @@
 from .network_delay import (
     NetworkDelayDetection,
     NetworkDelayLocalization,
+    NetworkDelayAnalysis,
+    NetworkDelayMitigation,
 )

--- a/aiopslab/orchestrator/problems/network_delay/network_delay.py
+++ b/aiopslab/orchestrator/problems/network_delay/network_delay.py
@@ -46,6 +46,65 @@ class NetworkDelayBaseTask:
         self.injector.recover_network_delay()
 
 
+def evaluate_network_delay_analysis_solution(task, soln: Any) -> dict:
+    """Validate the RCA response for the static network delay scenario."""
+
+    if not isinstance(soln, dict):
+        print("Solution is not a dictionary")
+        task.results["system_level_correct"] = False
+        task.results["fault_type_correct"] = False
+        task.results["success"] = False
+        return task.results
+
+    system_level = soln.get("system_level", "")
+    fault_type = soln.get("fault_type", "")
+
+    is_sys_level_correct = is_exact_match_lower(system_level, "Application")
+    is_fault_type_correct = is_exact_match_lower(fault_type, "Network/Storage Issue")
+
+    if is_sys_level_correct:
+        print("System level analysis correct: Application")
+    else:
+        print(f"Incorrect system level analysis: {system_level}")
+
+    if is_fault_type_correct:
+        print("Fault type analysis correct: Network/Storage Issue")
+    else:
+        print(f"Incorrect fault type analysis: {fault_type}")
+
+    task.results["system_level_correct"] = is_sys_level_correct
+    task.results["fault_type_correct"] = is_fault_type_correct
+    task.results["success"] = is_sys_level_correct and is_fault_type_correct
+
+    return task.results
+
+
+def evaluate_network_delay_mitigation(task) -> bool:
+    """Check that the delayed service's pods are Ready before passing mitigation."""
+
+    pods_ready = task._check_pods_ready(
+        {
+            "namespace": task.namespace,
+            "services": [task.faulty_service],
+            "timeout": 60,
+            "interval": 5,
+        }
+    )
+    print(
+        "Mitigation pods_ready check for service"
+        f" '{task.faulty_service}' returned: {pods_ready}"
+    )
+
+    task.add_result("mitigation_pods_ready", pods_ready)
+
+    previous_success = task.results.get("success")
+    task.results["success"] = pods_ready if previous_success is None else (
+        previous_success and pods_ready
+    )
+
+    return task.results["success"]
+
+
 ################## Detection Problem ##################
 class NetworkDelayDetection(NetworkDelayBaseTask, DetectionTask):
     def __init__(self):
@@ -107,5 +166,35 @@ class NetworkDelayLocalization(NetworkDelayBaseTask, LocalizationTask):
 
         self.results["success"] = is_exact or (is_sub and len(soln) == 1)
         self.results["is_subset"] = is_sub
+
+        return self.results
+
+
+################## Root cause analysis Problem ##################
+class NetworkDelayAnalysis(NetworkDelayBaseTask, AnalysisTask):
+    def __init__(self):
+        NetworkDelayBaseTask.__init__(self)
+        AnalysisTask.__init__(self, self.app)
+
+    def eval(self, soln: Any, trace: list[SessionItem], duration: float):
+        print("== Evaluation ==")
+
+        evaluate_network_delay_analysis_solution(self, soln)
+        super().eval(soln, trace, duration)
+
+        return self.results
+
+
+################## Mitigation Problem ##################
+class NetworkDelayMitigation(NetworkDelayBaseTask, MitigationTask):
+    def __init__(self):
+        NetworkDelayBaseTask.__init__(self)
+        MitigationTask.__init__(self, self.app)
+
+    def eval(self, soln: Any, trace: list[SessionItem], duration: float) -> dict:
+        print("== Evaluation ==")
+
+        super().eval(soln, trace, duration)
+        evaluate_network_delay_mitigation(self)
 
         return self.results

--- a/aiopslab/orchestrator/problems/registry.py
+++ b/aiopslab/orchestrator/problems/registry.py
@@ -205,6 +205,8 @@ class ProblemRegistry:
             # Network delay
             "network_delay_hotel_res-detection-1": NetworkDelayDetection,
             "network_delay_hotel_res-localization-1": NetworkDelayLocalization,
+            "network_delay_hotel_res-analysis-1": NetworkDelayAnalysis,
+            "network_delay_hotel_res-mitigation-1": NetworkDelayMitigation,
             # No operation
             "noop_detection_hotel_reservation-1": lambda: NoOpDetection(
                 app_name="hotel"

--- a/docs/variant_catalogue.md
+++ b/docs/variant_catalogue.md
@@ -194,7 +194,9 @@ Variant mode is layered on top of a much broader pool of static incidents. The
   replicas (invalid tolerations, storage class, update strategy, security
   context) that can be re-enabled as those exercises mature.
 - **Chaos experiments without variants (yet)**: container/pod failure, network
-  loss/delay and kernel fault prototypes that can still be run in static mode.
+  loss/delay (the network delay static track now includes RCA validation of
+  `Application` / `Network/Storage Issue` and a pods-ready mitigation gate) and
+  kernel fault prototypes that can still be run in static mode.
 - **Application-specific outages**: Astronomy Shop feature-flag incidents,
   Payment Service/Recommendation Service failures, Kafka queue saturation and
   Flower platform experiments (`flower_*`).


### PR DESCRIPTION
## Summary
- add static analysis and mitigation implementations for the Hotel Reservation network delay scenario, including RCA validation and pod readiness checks
- expose the new tasks through the problem registry and module exports so they receive canonical IDs
- document the expanded static coverage in the variant catalogue

## Testing
- pytest tests/orchestrator/test_variant_scenarios.py

------
https://chatgpt.com/codex/tasks/task_e_68cdfbda57dc8330a465f08aeef0c6cd