### PR TITLE
Add network loss analysis and mitigation tasks

### DIFF
--- a/aiopslab/orchestrator/problems/network_loss/__init__.py
+++ b/aiopslab/orchestrator/problems/network_loss/__init__.py
@@ -4,4 +4,6 @@
 from .network_loss import (
     NetworkLossDetection,
     NetworkLossLocalization,
+    NetworkLossAnalysis,
+    NetworkLossMitigation,
 )

--- a/aiopslab/orchestrator/problems/registry.py
+++ b/aiopslab/orchestrator/problems/registry.py
@@ -202,6 +202,8 @@ class ProblemRegistry:
             # Network loss
             "network_loss_hotel_res-detection-1": NetworkLossDetection,
             "network_loss_hotel_res-localization-1": NetworkLossLocalization,
+            "network_loss_hotel_res-analysis-1": NetworkLossAnalysis,
+            "network_loss_hotel_res-mitigation-1": NetworkLossMitigation,
             # Network delay
             "network_delay_hotel_res-detection-1": NetworkDelayDetection,
             "network_delay_hotel_res-localization-1": NetworkDelayLocalization,

--- a/docs/variant_catalogue.md
+++ b/docs/variant_catalogue.md
@@ -110,17 +110,17 @@ curriculum authors can quickly inspect the grading logic.
   simulating packet loss via `inject_network_loss`.
 - **Variant coverage**: [`NetworkLossVariantBase`](../aiopslab/orchestrator/problems/network_loss/network_loss_variant.py)
   picks the affected service and loss rate.
-- **Analysis expectations**: variant RCA expects
+- **Analysis expectations**: static and variant RCA expect
   `system_level="Application"` / `fault_type="Network/Storage Issue"`.
-- **Mitigation checks**: variant mitigation relies on `pods_ready` for the
-  targeted service.
+- **Mitigation checks**: static and variant mitigation rely on `pods_ready`
+  for the targeted service.
 
 | Role | Static task | Variant task | Evaluation focus |
 | --- | --- | --- | --- |
 | Detection | [`NetworkLossDetection`](../aiopslab/orchestrator/problems/network_loss/network_loss.py) | [`NetworkLossVariantDetection`](../aiopslab/orchestrator/problems/network_loss/network_loss_variant.py) | Case-insensitive `"Yes"`. |
 | Localization | [`NetworkLossLocalization`](../aiopslab/orchestrator/problems/network_loss/network_loss.py) | [`NetworkLossVariantLocalization`](../aiopslab/orchestrator/problems/network_loss/network_loss_variant.py) | Requires the degraded service name. |
-| Analysis | – | [`NetworkLossVariantAnalysis`](../aiopslab/orchestrator/problems/network_loss/network_loss_variant.py) | Validates `Application` / `Network/Storage Issue`. |
-| Mitigation | – | [`NetworkLossVariantMitigation`](../aiopslab/orchestrator/problems/network_loss/network_loss_variant.py) | Checks that pods for the affected service are ready. |
+| Analysis | [`NetworkLossAnalysis`](../aiopslab/orchestrator/problems/network_loss/network_loss.py) | [`NetworkLossVariantAnalysis`](../aiopslab/orchestrator/problems/network_loss/network_loss_variant.py) | Validates `Application` / `Network/Storage Issue`. |
+| Mitigation | [`NetworkLossMitigation`](../aiopslab/orchestrator/problems/network_loss/network_loss.py) | [`NetworkLossVariantMitigation`](../aiopslab/orchestrator/problems/network_loss/network_loss_variant.py) | Checks that pods for the affected service are ready. |
 
 ## Hotel Reservation network delay
 


### PR DESCRIPTION
## Summary
- add dedicated analysis and mitigation task implementations for the hotel reservation network loss scenario
- expose the new tasks via the problem registry and network loss package exports
- document the static coverage for network loss analysis/mitigation in the variant catalogue

## Testing
- pytest tests/orchestrator/test_variant_scenarios.py -k network_loss

------
https://chatgpt.com/codex/tasks/task_e_68cdfbe47658833090d79625698d7c7c