### PR TITLE
Add container kill analysis and mitigation tasks

### DIFF
--- a/aiopslab/orchestrator/problems/container_kill/__init__.py
+++ b/aiopslab/orchestrator/problems/container_kill/__init__.py
@@ -1,1 +1,13 @@
-from .container_kill import ContainerKillDetection, ContainerKillLocalization
+from .container_kill import (
+    ContainerKillAnalysis,
+    ContainerKillDetection,
+    ContainerKillLocalization,
+    ContainerKillMitigation,
+)
+
+__all__ = [
+    "ContainerKillAnalysis",
+    "ContainerKillDetection",
+    "ContainerKillLocalization",
+    "ContainerKillMitigation",
+]

--- a/aiopslab/orchestrator/problems/registry.py
+++ b/aiopslab/orchestrator/problems/registry.py
@@ -25,8 +25,10 @@ from aiopslab.orchestrator.problems.scale_pod.scale_pod_variant import (
 from aiopslab.orchestrator.problems.assign_non_existent_node import *
 from aiopslab.orchestrator.problems.container_kill import *
 from aiopslab.orchestrator.problems.container_kill.container_kill_variant import (
+    ContainerKillVariantAnalysis,
     ContainerKillVariantDetection,
     ContainerKillVariantLocalization,
+    ContainerKillVariantMitigation,
 )
 from aiopslab.orchestrator.problems.pod_failure import *
 from aiopslab.orchestrator.problems.pod_failure.pod_failure_variant import (
@@ -192,7 +194,13 @@ class ProblemRegistry:
             "assign_to_non_existent_node_social_net-mitigation-1": AssignNonExistentNodeSocialNetMitigation,
             # Chaos mesh container kill
             "container_kill-detection": ContainerKillDetection,
+            "container_kill-detection-1": ContainerKillDetection,
             "container_kill-localization": ContainerKillLocalization,
+            "container_kill-localization-1": ContainerKillLocalization,
+            "container_kill-analysis": ContainerKillAnalysis,
+            "container_kill-analysis-1": ContainerKillAnalysis,
+            "container_kill-mitigation": ContainerKillMitigation,
+            "container_kill-mitigation-1": ContainerKillMitigation,
             # Pod failure
             "pod_failure_hotel_res-detection-1": PodFailureDetection,
             "pod_failure_hotel_res-localization-1": PodFailureLocalization,
@@ -509,7 +517,37 @@ class ProblemRegistry:
                 faulty_container="hotel-reserv-geo",
                 enable_variants=True,
             ),
+            "container_kill-detection-1": lambda: ContainerKillVariantDetection(
+                faulty_service="geo",
+                faulty_container="hotel-reserv-geo",
+                enable_variants=True,
+            ),
             "container_kill-localization": lambda: ContainerKillVariantLocalization(
+                faulty_service="geo",
+                faulty_container="hotel-reserv-geo",
+                enable_variants=True,
+            ),
+            "container_kill-localization-1": lambda: ContainerKillVariantLocalization(
+                faulty_service="geo",
+                faulty_container="hotel-reserv-geo",
+                enable_variants=True,
+            ),
+            "container_kill-analysis": lambda: ContainerKillVariantAnalysis(
+                faulty_service="geo",
+                faulty_container="hotel-reserv-geo",
+                enable_variants=True,
+            ),
+            "container_kill-analysis-1": lambda: ContainerKillVariantAnalysis(
+                faulty_service="geo",
+                faulty_container="hotel-reserv-geo",
+                enable_variants=True,
+            ),
+            "container_kill-mitigation": lambda: ContainerKillVariantMitigation(
+                faulty_service="geo",
+                faulty_container="hotel-reserv-geo",
+                enable_variants=True,
+            ),
+            "container_kill-mitigation-1": lambda: ContainerKillVariantMitigation(
                 faulty_service="geo",
                 faulty_container="hotel-reserv-geo",
                 enable_variants=True,

--- a/docs/variant_catalogue.md
+++ b/docs/variant_catalogue.md
@@ -146,17 +146,18 @@ curriculum authors can quickly inspect the grading logic.
   drives Chaos Mesh to terminate the selected container.
 - **Variant coverage**: [`ContainerKillVariantBase`](../aiopslab/orchestrator/problems/container_kill/container_kill_variant.py)
   enumerates service/container pairs across the application.
-- **Analysis expectations**: variant RCA expects
+- **Analysis expectations**: both static and variant RCAs expect
   `system_level="Virtualization"` / `fault_type="Operation Error"`.
-- **Mitigation checks**: variant mitigation uses `pods_ready` for the affected
-  service.
+- **Mitigation checks**: the static task polls until the affected service's pods
+  are ready again, while the variant metadata uses the mixin's `pods_ready`
+  expectation for that service.
 
 | Role | Static task | Variant task | Evaluation focus |
 | --- | --- | --- | --- |
 | Detection | [`ContainerKillDetection`](../aiopslab/orchestrator/problems/container_kill/container_kill.py) | [`ContainerKillVariantDetection`](../aiopslab/orchestrator/problems/container_kill/container_kill_variant.py) | Case-insensitive `"Yes"`. |
 | Localization | [`ContainerKillLocalization`](../aiopslab/orchestrator/problems/container_kill/container_kill.py) | [`ContainerKillVariantLocalization`](../aiopslab/orchestrator/problems/container_kill/container_kill_variant.py) | Requires the affected service (static) or service/container (variant metadata). |
-| Analysis | – | [`ContainerKillVariantAnalysis`](../aiopslab/orchestrator/problems/container_kill/container_kill_variant.py) | Validates `Virtualization` / `Operation Error`. |
-| Mitigation | – | [`ContainerKillVariantMitigation`](../aiopslab/orchestrator/problems/container_kill/container_kill_variant.py) | Uses `pods_ready` checks. |
+| Analysis | [`ContainerKillAnalysis`](../aiopslab/orchestrator/problems/container_kill/container_kill.py) | [`ContainerKillVariantAnalysis`](../aiopslab/orchestrator/problems/container_kill/container_kill_variant.py) | Validates `Virtualization` / `Operation Error`. |
+| Mitigation | [`ContainerKillMitigation`](../aiopslab/orchestrator/problems/container_kill/container_kill.py) | [`ContainerKillVariantMitigation`](../aiopslab/orchestrator/problems/container_kill/container_kill_variant.py) | Confirms the targeted service's pods return to ready state. |
 
 ## TiDB operator misoperation
 


### PR DESCRIPTION
## Summary
- add evaluation helpers plus ContainerKillAnalysis and ContainerKillMitigation that enforce virtualization/operation error scope and poll pods for readiness
- expose the new tasks through the container_kill package and register them (with variant constructors) in the ProblemRegistry
- document full four-role coverage for the Hotel Reservation container-kill incident in the variant catalogue

## Testing
- `poetry run pytest tests/registry/test_get_actions.py` *(fails: missing aiopslab/config.yml in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfbeab2108330b7654229aa3f23bb