### PR TITLE
Expose RL environment through FastAPI service

### DIFF
--- a/service.py
+++ b/service.py
@@ -6,7 +6,7 @@ import os
 import traceback
 from dataclasses import dataclass
 from threading import Lock
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from uuid import uuid4
 
 if TYPE_CHECKING:  # pragma: no cover - import only for static analysis
@@ -327,3 +327,23 @@ def step_rl_environment(
         reward=reward,
         info=response_info,
     )
+
+
+def get_rl_environment_state(env_id: str) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Return the cached observation/info for a managed environment."""
+
+    managed = _get_managed_env(env_id)
+    return managed.initial_observation, managed.initial_info
+
+
+def close_rl_environment(env_id: str) -> None:
+    """Terminate and discard a managed RL environment."""
+
+    managed = _get_managed_env(env_id)
+
+    try:
+        managed.env.close()
+    finally:
+        managed.done = True
+        with _RL_ENV_LOCK:
+            _RL_ENVIRONMENTS.pop(env_id, None)

--- a/service_api.py
+++ b/service_api.py
@@ -1,0 +1,174 @@
+"""FastAPI surface for interacting with ProblemRLEnvironment sessions.
+
+This module wraps the imperative helpers in :mod:`service` and exposes them as a
+REST interface so external orchestrators (for example Echo's rollout workers)
+can create environments, advance them step-by-step, and tear them down via
+simple HTTP calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException, Path
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+import service
+
+
+app = FastAPI(
+    title="AIOpsLab RL Environment API",
+    description=(
+        "Expose ProblemRLEnvironment reset/step/close operations so external"
+        " reinforcement-learning systems can interact with the simulator over"
+        " HTTP."
+    ),
+    version="0.1.0",
+)
+
+
+class RewardConfigPayload(BaseModel):
+    success: Optional[float] = None
+    invalid_submission: Optional[float] = None
+    step: Optional[float] = None
+    timeout: Optional[float] = None
+    command_match_multiplier: Optional[float] = None
+
+
+class ResetRequest(BaseModel):
+    problem_id: str = Field(..., description="Identifier of the orchestrator problem to load.")
+    max_steps: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optional override for the number of turns before timeout.",
+    )
+    reward_config: Optional[RewardConfigPayload] = Field(
+        default=None,
+        description="Overrides for the reward parameters applied to the episode.",
+    )
+    ground_truth_dir: Optional[str] = Field(
+        default=None,
+        description="Path to an alternate ground-truth power model directory.",
+    )
+
+
+class ResetResponse(BaseModel):
+    env_id: str
+    observation: Dict[str, Any]
+    info: Dict[str, Any]
+
+
+class StepRequest(BaseModel):
+    step: int = Field(..., ge=0, description="Sequential step number for the episode.")
+    action: Optional[str] = Field(
+        default=None,
+        description="Agent action to execute on this step (required when step > 0).",
+    )
+    llm_response: Optional[str] = Field(
+        default=None,
+        description="Optional reasoning text from the policy to include in the trace.",
+    )
+    llm_raw_response: Optional[str] = Field(
+        default=None,
+        description="Optional raw generation from the policy to include in the trace.",
+    )
+
+
+class StepResponse(BaseModel):
+    state: Any
+    actions_left: int
+    actions: Dict[str, Any]
+    reward: float
+    info: Dict[str, Any]
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    """Return a heartbeat payload for monitoring probes."""
+
+    return service.health_check()
+
+
+@app.get("/problems")
+def problems() -> Dict[str, Any]:
+    """Expose the available problem identifiers."""
+
+    return {"problems": service.list_problems()}
+
+
+@app.get("/agents")
+def agents() -> Dict[str, Any]:
+    """Expose the available agent identifiers."""
+
+    return {"agents": service.list_agents()}
+
+
+def _build_reward_config(payload: RewardConfigPayload | None):
+    if payload is None:
+        return None
+
+    from aiopslab.orchestrator.rl_env import RewardConfig
+
+    kwargs = payload.model_dump(exclude_none=True)
+    return RewardConfig(**kwargs)
+
+
+def _handle_service_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, service.RLEnvironmentNotFoundError):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, service.RLEnvironmentFinishedError):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(exc, (service.RLEnvironmentError, ValueError)):
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail=str(exc))
+
+
+@app.post("/rl/reset", response_model=ResetResponse)
+def reset(payload: ResetRequest) -> ResetResponse:
+    """Create and reset a managed RL environment."""
+
+    reward_config = _build_reward_config(payload.reward_config)
+    try:
+        handle = service.reset_rl_environment(
+            payload.problem_id,
+            max_steps=payload.max_steps,
+            reward_config=reward_config,
+            ground_truth_dir=payload.ground_truth_dir,
+        )
+        observation, info = service.get_rl_environment_state(handle.env_id)
+    except Exception as exc:  # pragma: no cover - defensive mapping
+        raise _handle_service_error(exc) from exc
+
+    return ResetResponse(env_id=handle.env_id, observation=observation, info=info)
+
+
+@app.post("/rl/{env_id}/step", response_model=StepResponse)
+def step(env_id: str, payload: StepRequest) -> StepResponse:
+    """Advance the specified environment by one step."""
+
+    try:
+        step_result = service.step_rl_environment(
+            env_id,
+            step=payload.step,
+            action=payload.action,
+            llm_response=payload.llm_response,
+            llm_raw_response=payload.llm_raw_response,
+        )
+    except Exception as exc:  # pragma: no cover - defensive mapping
+        raise _handle_service_error(exc) from exc
+
+    return StepResponse(**asdict(step_result))
+
+
+@app.delete("/rl/{env_id}")
+def close(env_id: str = Path(..., description="Environment identifier returned by reset.")) -> JSONResponse:
+    """Close and discard the specified environment."""
+
+    try:
+        service.close_rl_environment(env_id)
+    except Exception as exc:  # pragma: no cover - defensive mapping
+        raise _handle_service_error(exc) from exc
+
+    return JSONResponse(status_code=204, content={})

--- a/tests/test_service_api.py
+++ b/tests/test_service_api.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+import service
+import service_api
+
+
+class StubRLEnvironment:
+    def __init__(self):
+        self.problems = {}
+        self.orchestrator = types.SimpleNamespace(
+            session=types.SimpleNamespace(history=[])
+        )
+        self.closed = False
+        self._step_count = 0
+
+    def reset(self, problem_id):
+        self.problems[problem_id] = True
+        observation = {
+            "state": f"initial state for {problem_id}",
+            "actions_left": 3,
+        }
+        info = {
+            "actions": {"exec": "execute"},
+            "available_actions": ["exec"],
+        }
+        return observation, info
+
+    def step(self, action):
+        self._step_count += 1
+        self.orchestrator.session.history.append({"role": "assistant"})
+        observation = {
+            "state": f"after {action}",
+            "actions_left": max(3 - self._step_count, 0),
+        }
+        done = self._step_count >= 2
+        info = {
+            "actions": {"exec": "execute"},
+            "terminated": done,
+            "truncated": False,
+        }
+        return observation, 1.0, done, info
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    service._RL_ENVIRONMENTS.clear()
+    yield
+    service._RL_ENVIRONMENTS.clear()
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    stub_envs: list[StubRLEnvironment] = []
+
+    def _factory(*args, **kwargs):
+        env = StubRLEnvironment()
+        stub_envs.append(env)
+        return env
+
+    monkeypatch.setattr(service, "_create_rl_environment", _factory)
+    return TestClient(service_api.app), stub_envs
+
+
+def test_reset_and_step_endpoint(client):
+    test_client, stub_envs = client
+
+    response = test_client.post("/rl/reset", json={"problem_id": "prob-1", "max_steps": 5})
+    assert response.status_code == 200
+    payload = response.json()
+    env_id = payload["env_id"]
+    assert payload["observation"]["state"] == "initial state for prob-1"
+    assert payload["info"]["actions"] == {"exec": "execute"}
+
+    step_zero = test_client.post(f"/rl/{env_id}/step", json={"step": 0})
+    assert step_zero.status_code == 200
+    assert step_zero.json()["reward"] == 0.0
+
+    step_one = test_client.post(
+        f"/rl/{env_id}/step",
+        json={"step": 1, "action": "exec", "llm_response": "analysis"},
+    )
+    assert step_one.status_code == 200
+    assert step_one.json()["state"] == "after exec"
+
+    step_two = test_client.post(f"/rl/{env_id}/step", json={"step": 2, "action": "exec"})
+    assert step_two.status_code == 200
+    assert step_two.json()["info"]["environment"]["done"] is True
+    assert stub_envs[0].closed is True
+
+    missing = test_client.post(f"/rl/{env_id}/step", json={"step": 3, "action": "exec"})
+    assert missing.status_code == 404
+
+
+def test_close_endpoint(client):
+    test_client, stub_envs = client
+
+    response = test_client.post("/rl/reset", json={"problem_id": "prob-1"})
+    env_id = response.json()["env_id"]
+    assert stub_envs[0].closed is False
+
+    close = test_client.delete(f"/rl/{env_id}")
+    assert close.status_code == 204
+    assert stub_envs[0].closed is True
+
+    second_close = test_client.delete(f"/rl/{env_id}")
+    assert second_close.status_code == 404


### PR DESCRIPTION
## Summary
- add getters and cleanup helpers for managed RL environments
- expose FastAPI endpoints for resetting, stepping, and closing RL environments so Echo can interact over HTTP
- cover the new surface with unit tests for both the service helpers and API layer

## Testing
- pytest tests/test_service_rl_env.py tests/test_service_api.py

------
https://chatgpt.com/codex/tasks/task_e_68f8311d5440833080ee511b7d452655